### PR TITLE
Fix hydra logging directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To launch the simulation with default settings, use the following command in a s
 working directory being the project root:
 
 ```sh
-python ethicalgardeners/main.py --config-name config
+python -m ethicalgardeners.main --config-name config
 ```
 
 ### Run tests

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,3 +10,9 @@ defaults:
 random_seed: 42
 num_iterations: 1000
 render_mode: "human"  # "none" or "human"
+
+# Hydra overrides
+hydra:
+  run:
+    dir: ${metrics.out_dir_path}   # put Hydra outputs next to the metrics
+  output_subdir: .hydra

--- a/configs/metrics/export.yaml
+++ b/configs/metrics/export.yaml
@@ -1,3 +1,3 @@
-out_dir_path: "./metrics"
+out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
 export_on: true
 send_on: false

--- a/configs/metrics/full.yaml
+++ b/configs/metrics/full.yaml
@@ -1,3 +1,3 @@
-out_dir_path: "./metrics"
+out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
 export_on: true
 send_on: true

--- a/configs/metrics/none.yaml
+++ b/configs/metrics/none.yaml
@@ -1,3 +1,3 @@
-out_dir_path: "./metrics"
+out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
 export_on: false
 send_on: false

--- a/configs/metrics/send.yaml
+++ b/configs/metrics/send.yaml
@@ -1,3 +1,3 @@
-out_dir_path: "./metrics"
+out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
 export_on: false
 send_on: true

--- a/configs/renderer/console.yaml
+++ b/configs/renderer/console.yaml
@@ -3,7 +3,7 @@ graphical:
 console:
   enabled: true
   post_analysis_on: true
-  out_dir_path: "./videos"
+  out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
   characters:
     ground: " "
     obstacle: "#"

--- a/configs/renderer/full.yaml
+++ b/configs/renderer/full.yaml
@@ -1,7 +1,7 @@
 graphical:
   enabled: true
   post_analysis_on: true
-  out_dir_path: "./videos"
+  out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
   cell_size: 50
   colors:
     background: [255, 255, 255]
@@ -10,7 +10,7 @@ graphical:
 console:
   enabled: true
   post_analysis_on: false
-  out_dir_path: "./videos"
+  out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
   characters:
     ground: " "
     obstacle: "#"

--- a/configs/renderer/graphical.yaml
+++ b/configs/renderer/graphical.yaml
@@ -1,7 +1,7 @@
 graphical:
   enabled: true
   post_analysis_on: true
-  out_dir_path: "./videos"
+  out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
   cell_size: 50
   colors:
     background: [255, 255, 255]

--- a/docs/source/examples/full_config.yaml
+++ b/docs/source/examples/full_config.yaml
@@ -80,7 +80,7 @@ observation:
 
 # Metrics configuration
 metrics:
-  out_dir_path: "./metrics"
+  out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
   export_on: true
   send_on: false
 
@@ -89,7 +89,7 @@ renderer:
   graphical:
     enabled: true
     post_analysis_on: false
-    out_dir_path: "./videos"
+    out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
     cell_size: 50
     colors:
       background: [255, 255, 255]
@@ -97,7 +97,7 @@ renderer:
   console:
     enabled: false
     post_analysis_on: false
-    out_dir_path: "./videos"
+    out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
     characters:
       ground: " "
       wall: "#"

--- a/docs/source/examples/grid_config.txt
+++ b/docs/source/examples/grid_config.txt
@@ -1,0 +1,16 @@
+10 10
+G G G O O G G G G G
+G F0_2 G G G O G G G G
+G O G A0 O G G G G G
+G G G G O G G G G G
+O O O O O G G G G G
+G G G G G G G G G G
+G G G G G G G A1 G G
+G G G G G G G G G G
+G G G G G G G G G G
+G G G G G G G G G G
+0,100,5|10|3
+1,100,5|10|3
+0,10,1|2|5
+1,5,0|1|3
+2,2,0|1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,13 +33,8 @@ For metrics tracking (wandb):
 Quick Start
 -----------
 
-To run the simulation with the default configuration. After cloning the project, at the project root, use the following command:
-
-.. code-block:: bash
-
-    python ethicalgardeners/main.py --config-name config
-
-After installing the package using pip, you can run instead:
+To run the simulation with the default configuration. After cloning the project, at the project root or after installing
+the package using pypi, use the following command:
 
 .. code-block:: bash
 

--- a/docs/source/tutorials/config.rst
+++ b/docs/source/tutorials/config.rst
@@ -102,27 +102,15 @@ Three initialization methods are available:
    the file should be formatted as follows:
 
    - First line: width height
-   - Grid representation: G (ground), O (obstacle), FX_Y (ground with flower type X at growth stage Y), AX (ground with agent ID X)
+   - Grid representation: G (ground), O (obstacle), FX_Y_Z (ground with flower type X planted by agent of id Y at growth stage Z), AX (ground with agent ID X)
    - Agent definitions: ID,money,seeds (of type 0| of type 1| of type 2)
    - Flower types definitions: type,price,pollution_reduction (for stage 0| stage 1| stage 2)
 
-   .. code-block:: text
-
-      10 10
-      G G G O O G G G G G
-      G F0_2 G G G O G G G G
-      G O G A0 O G G G G G
-      G G G G O G G G G G
-      O O O O O G G G G G
-      G G G G G G G G G G
-      G G G G G G G G G G
-      G G G G G G G G G G
-      G G G G G G G G G G
-      G G G G G G G G G G
-      0,100,5|10|3
-      0,10,5|2|1
-      1,5,3|1|0
-      2,2,1|0
+   .. literalinclude:: /examples/grid_config.txt
+      :language: text
+      :caption: grid_config.txt
+      :name: grid_config
+      :encoding: utf-8
 
 Common Grid Parameters
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -201,9 +189,9 @@ The metrics configuration controls how simulation data is collected and exported
 
 .. code-block:: yaml
 
-    out_dir_path: "./metrics"  # Directory for metrics output
-    export_on: true            # Export metrics to CSV files
-    send_on: false             # Send metrics to external services (e.g., Weights & Biases)
+    out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}  # Directory for metrics output
+    export_on: true                                        # Export metrics to CSV files
+    send_on: false                                         # Send metrics to external services (e.g., Weights & Biases)
 
 Collected metrics include:
 
@@ -212,6 +200,17 @@ Collected metrics include:
 - Pollution levels (average and thresholds)
 - Agent rewards
 - Currently active agent
+
+Hydra supports dynamic expressions, so you can use `${now: }` with:
+
+- `%Y`: Year
+- `%m`: Month
+- `%d`: Day of the month
+- `%H`: Hour (24-hour clock)
+- `%M`: Minute
+- `%S`: Second
+
+By default, the output directory will be outputs/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND. This directory will store the csv file named metrics_run.csv as well as the hydra configuration used for the simulation in the ``.hydra`` directory and the logs.
 
 .. _wandb-parameters:
 
@@ -230,7 +229,7 @@ Example:
 .. code-block:: yaml
 
     metrics:
-      out_dir_path: "./metrics"
+      out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
       export_on: true
       send_on: true
       wandb:
@@ -420,7 +419,7 @@ When specifying configurations, it's important to follow Hydra's hierarchical st
       range: 1
 
     metrics:
-      out_dir_path: "./metrics"
+      out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
       export_on: true
       send_on: false
 

--- a/docs/source/tutorials/config.rst
+++ b/docs/source/tutorials/config.rst
@@ -210,7 +210,7 @@ Hydra supports dynamic expressions, so you can use `${now: }` with:
 - `%M`: Minute
 - `%S`: Second
 
-By default, the output directory will be outputs/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND. This directory will store the csv file named metrics_run.csv as well as the hydra configuration used for the simulation in the ``.hydra`` directory and the logs.
+By default, the output directory will be outputs/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND. This directory will store the csv file named simulation_metrics.csv as well as the hydra configuration used for the simulation in the ``.hydra`` directory and the logs.
 
 .. _wandb-parameters:
 
@@ -259,9 +259,9 @@ Two types of renderers are available and can be used individually or together:
 
       console:
         enabled: true
-        post_analysis_on: false    # Save graphical visualization as video by creating a GraphicalRenderer without display
-        out_dir_path: "./videos"   # Directory for video output
-        characters:                # Customizable characters for different elements
+        post_analysis_on: false                                 # Save graphical visualization as video by creating a GraphicalRenderer without display
+        out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}   # Directory for video output
+        characters:                                             # Customizable characters for different elements
           ground: " "
           obstacle: "#"
           agent: "A"
@@ -275,10 +275,10 @@ Two types of renderers are available and can be used individually or together:
 
       graphical:
         enabled: true
-        post_analysis_on: false    # Save visualization as video
-        out_dir_path: "./videos"   # Directory for video output
-        cell_size: 50              # Size of each cell in pixels
-        colors:                    # Customizable color scheme
+        post_analysis_on: false                                 # Save visualization as video
+        out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}   # Directory for video output
+        cell_size: 50                                           # Size of each cell in pixels
+        colors:                                                 # Customizable color scheme
           background: [255, 255, 255]
           obstacle: [100, 100, 100]
           ground: [70, 255, 70]    # define the red and blue components of the displayed ground color
@@ -427,7 +427,7 @@ When specifying configurations, it's important to follow Hydra's hierarchical st
       console:
         enabled: true
         post_analysis_on: false
-        out_dir_path: "./videos"
+        out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
         cell_size: 50
         colors:
           background: [255, 255, 255]

--- a/docs/source/tutorials/config.rst
+++ b/docs/source/tutorials/config.rst
@@ -210,7 +210,7 @@ Hydra supports dynamic expressions, so you can use `${now: }` with:
 - `%M`: Minute
 - `%S`: Second
 
-By default, the output directory will be outputs/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND. This directory will store the csv file named simulation_metrics.csv as well as the hydra configuration used for the simulation in the ``.hydra`` directory and the logs.
+By default, the output directory will be outputs/YEAR-MONTH-DAY/HOUR-MINUTE-SECOND. This directory will store the csv file named ``simulation_metrics.csv`` as well as the hydra configuration used for the simulation in the ``.hydra`` directory and the logs.
 
 .. _wandb-parameters:
 

--- a/docs/source/tutorials/extend.rst
+++ b/docs/source/tutorials/extend.rst
@@ -632,7 +632,7 @@ To use this new renderer, you would configure it in your config:
       heatmap:
          enabled: true
          post_analysis_on: true
-         out_dir_path: "./videos"
+         out_dir_path: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
          cmap: 'coolwarm'
 
 And modify the :py:func:`~ethicalgardeners.main.make_env` function to include the new renderer:
@@ -648,7 +648,7 @@ And modify the :py:func:`~ethicalgardeners.main.make_env` function to include th
             post_analysis_on = config.renderer.heatmap.get(
                 "post_analysis_on",  False
             )
-            out_dir = config.renderer.heatmap.get("out_dir_path", "./videos")
+            out_dir = config.renderer.heatmap.get("out_dir_path", "outputs")
             cmap = config.renderer.heatmap.get("cmap", 'coolwarm')
 
             heatmap_renderer = HeatmapRenderer(

--- a/docs/source/tutorials/launch.rst
+++ b/docs/source/tutorials/launch.rst
@@ -36,13 +36,8 @@ Launching the Simulation
 Basic Launch Command
 ^^^^^^^^^^^^^^^^^^^^
 
-To run the simulation with the default configuration. After cloning the project, at the project root, use the following command:
-
-.. code-block:: bash
-
-    python ethicalgardeners/main.py --config-name config
-
-After installing the package using pip, you can also run:
+To run the simulation with the default configuration. After cloning the project, at the project root or after installing
+the package using pypi, use the following command:
 
 .. code-block:: bash
 
@@ -114,10 +109,11 @@ Where to Find Metrics
 
 When metrics export is enabled (``metrics=export`` or ``metrics=full``), metrics are saved to:
 
-- **Default path**: ``./metrics/metrics_run_[TIMESTAMP].csv``
+- **Default path**: ``./output/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND/metrics_run.csv``
 - **Custom path**: Specified via ``metrics.out_dir_path=your/custom/path``
 
-The CSV file contains all metrics for each step of the simulation.
+The CSV file contains all metrics for each step of the simulation. In this directory, you can also find the hydra configuration
+used for the simulation in ``.hydra`` and the logs.
 
 Sending Metrics to External Services
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/tutorials/launch.rst
+++ b/docs/source/tutorials/launch.rst
@@ -109,7 +109,7 @@ Where to Find Metrics
 
 When metrics export is enabled (``metrics=export`` or ``metrics=full``), metrics are saved to:
 
-- **Default path**: ``./output/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND/simulation_metrics.csv``
+- **Default path**: ``./output/YEAR-MONTH-DAY/HOUR-MINUTE-SECOND/simulation_metrics.csv``
 - **Custom path**: Specified via ``metrics.out_dir_path=your/custom/path``
 
 The CSV file contains all metrics for each step of the simulation. In this directory, you can also find the hydra configuration
@@ -157,7 +157,7 @@ Where to Find post-analysis Videos
 
 When post-analysis is enabled (``renderer.console.post_analysis_on=True`` or ``renderer.graphical.post_analysis_on=True``), videos using the graphical visualization are saved to the same directory as metrics:
 
-- **Default path**: ``./output/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND/simulation_video.mp4``
+- **Default path**: ``./output/YEAR-MONTH-DAY/HOUR-MINUTE-SECOND/simulation_video.mp4``
 - **Custom path**: Specified via ``renderer.console.out_dir_path`` or ``renderer.graphical.out_dir_path``
 
 Example: Complete Analysis Configuration

--- a/docs/source/tutorials/launch.rst
+++ b/docs/source/tutorials/launch.rst
@@ -109,7 +109,7 @@ Where to Find Metrics
 
 When metrics export is enabled (``metrics=export`` or ``metrics=full``), metrics are saved to:
 
-- **Default path**: ``./output/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND/metrics_run.csv``
+- **Default path**: ``./output/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND/simulation_metrics.csv``
 - **Custom path**: Specified via ``metrics.out_dir_path=your/custom/path``
 
 The CSV file contains all metrics for each step of the simulation. In this directory, you can also find the hydra configuration
@@ -155,9 +155,9 @@ In the console visualization, by default:
 Where to Find post-analysis Videos
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When post-analysis is enabled (``renderer.console.post_analysis_on=True`` or ``renderer.graphical.post_analysis_on=True``), videos using the graphical visualization are saved to:
+When post-analysis is enabled (``renderer.console.post_analysis_on=True`` or ``renderer.graphical.post_analysis_on=True``), videos using the graphical visualization are saved to the same directory as metrics:
 
-- **Default path**: ``./videos/simulation_video_[TIMESTAMP].mp4``
+- **Default path**: ``./output/YEAR_MONTH_DAY/HOUR_MINUTE_SECOND/simulation_video.mp4``
 - **Custom path**: Specified via ``renderer.console.out_dir_path`` or ``renderer.graphical.out_dir_path``
 
 Example: Complete Analysis Configuration

--- a/ethicalgardeners/actionhandler.py
+++ b/ethicalgardeners/actionhandler.py
@@ -119,7 +119,7 @@ class ActionHandler:
             return
 
         agent.use_seed(flower_type)
-        self.grid_world.place_flower(agent.position, flower_type)
+        self.grid_world.place_flower(agent.position, flower_type, agent)
         agent.flowers_planted[flower_type] += 1
 
     def harvest_flower(self, agent: Agent):
@@ -166,8 +166,10 @@ class ActionHandler:
             self.grid_world.flowers_data[flower.flower_type]['price'])
         agent.turns_without_income = 0
 
-        agent.flowers_planted[flower.flower_type] -= 1
         agent.flowers_harvested[flower.flower_type] += 1
+
+        planter_agent = flower.planted_by
+        planter_agent.flowers_planted[flower.flower_type] -= 1
 
     def wait(self, agent: Agent):
         """

--- a/ethicalgardeners/actionhandler.py
+++ b/ethicalgardeners/actionhandler.py
@@ -169,7 +169,9 @@ class ActionHandler:
         agent.flowers_harvested[flower.flower_type] += 1
 
         planter_agent = flower.planted_by
-        planter_agent.flowers_planted[flower.flower_type] -= 1
+        # Remember that initially planted flowers do not have a planter
+        if planter_agent is not None:
+            planter_agent.flowers_planted[flower.flower_type] -= 1
 
     def wait(self, agent: Agent):
         """

--- a/ethicalgardeners/agent.py
+++ b/ethicalgardeners/agent.py
@@ -15,7 +15,8 @@ class Agent:
         money (float): The agent's current monetary wealth.
         seeds (dict): Dictionary mapping flower types to the number of seeds
             the agent has.
-        flowers_planted (dict): Counter of flowers planted by type.
+        flowers_planted (dict): Counter of flowers currently planted on the
+            grid by type.
         flowers_harvested (dict): Counter of flowers harvested by type.
         turns_without_income (int): Number of turns the agent has not earned
             money.

--- a/ethicalgardeners/agent.py
+++ b/ethicalgardeners/agent.py
@@ -15,9 +15,12 @@ class Agent:
         money (float): The agent's current monetary wealth.
         seeds (dict): Dictionary mapping flower types to the number of seeds
             the agent has.
-        flowers_planted (dict): Counter of flowers currently planted on the
-            grid by type.
-        flowers_harvested (dict): Counter of flowers harvested by type.
+        flowers_planted (dict): Counter of flowers this agent has planted on
+            the grid by type.
+        flowers_harvested (dict): Counter of flowers this agent has harvested
+            by type. (Note that, because an agent can harvest flowers planted
+            by another agent, this counter can be very different from the
+            ``flowers_planted`` counter.)
         turns_without_income (int): Number of turns the agent has not earned
             money.
         action_mask (list): Action mask indicating valid actions for the agent.

--- a/ethicalgardeners/main.py
+++ b/ethicalgardeners/main.py
@@ -139,7 +139,7 @@ def make_env(config=None):
     )
 
     # Initialise metrics collector
-    metrics_out_dir = config.metrics.get("out_dir_path", "./metrics")
+    metrics_out_dir = config.metrics.get("out_dir_path", "outputs")
     export_metrics = config.metrics.get("export_on", False)
     send_metrics = config.metrics.get("send_on", False)
 
@@ -177,7 +177,7 @@ def make_env(config=None):
         post_analysis_on = config.renderer.graphical.get(
             "post_analysis_on", False
         )
-        out_dir = config.renderer.graphical.get("out_dir_path", "./videos")
+        out_dir = config.renderer.graphical.get("out_dir_path", "outputs")
         cell_size = config.renderer.graphical.get("cell_size", 50)
         colors = config.renderer.graphical.get("colors", None)
 
@@ -195,7 +195,7 @@ def make_env(config=None):
         post_analysis_on = config.renderer.console.get(
             "post_analysis_on", False
         )
-        out_dir = config.renderer.console.get("out_dir_path", "./videos")
+        out_dir = config.renderer.console.get("out_dir_path", "outputs")
         characters = config.renderer.console.get("characters", None)
 
         console_renderer = ConsoleRenderer(

--- a/ethicalgardeners/main.py
+++ b/ethicalgardeners/main.py
@@ -4,6 +4,7 @@ Main entry point for the Ethical Gardeners simulation environment.
 import os
 import sys
 from importlib.resources import files
+import shutil
 
 import hydra
 import numpy as np
@@ -152,6 +153,20 @@ def make_env(config=None):
         send_metrics,
         **wandb_params
     )
+
+    # Delete hydra logs if export_on is False
+    if not export_metrics:
+        try:
+            run_dir = (
+                hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
+
+            hydra_dir = os.path.join(run_dir, ".hydra")
+
+            if os.path.isdir(hydra_dir):
+                shutil.rmtree(hydra_dir, ignore_errors=True)
+        except Exception:
+            pass  # If the passed config isn't a Hydra config (None or simple
+            # OmegaConf)
 
     # Initialise renderers
     renderers = []

--- a/ethicalgardeners/metricscollector.py
+++ b/ethicalgardeners/metricscollector.py
@@ -269,7 +269,8 @@ class MetricsCollector:
                 os.makedirs(self.out_dir_path)
 
             # Generate filename with run_id
-            filename = os.path.join(self.out_dir_path, "metrics_run.csv")
+            filename = os.path.join(self.out_dir_path,
+                                    "simulation_metrics.csv")
 
             # Prepare row with metrics
             metrics_row = self._prepare_metrics()

--- a/ethicalgardeners/metricscollector.py
+++ b/ethicalgardeners/metricscollector.py
@@ -269,8 +269,7 @@ class MetricsCollector:
                 os.makedirs(self.out_dir_path)
 
             # Generate filename with run_id
-            filename = os.path.join(self.out_dir_path,
-                                    f"metrics_run_{self._run_id}.csv")
+            filename = os.path.join(self.out_dir_path, "metrics_run.csv")
 
             # Prepare row with metrics
             metrics_row = self._prepare_metrics()

--- a/ethicalgardeners/renderer.py
+++ b/ethicalgardeners/renderer.py
@@ -290,8 +290,6 @@ class GraphicalRenderer(Renderer):
             when post_analysis_on is True.
         frames (list): Collection of rendered frames for video generation
             when post_analysis_on is True.
-        _run_id (int): Unique identifier for the run, used to name output files
-            when post_analysis_on is True.
     """
 
     def __init__(self, cell_size=32, colors=None, post_analysis_on=False,
@@ -348,13 +346,6 @@ class GraphicalRenderer(Renderer):
         # Create Pygame window and clock
         self.window = None
         self.clock = None
-
-        self._run_id = None  # Unique identifier for the run
-
-        if post_analysis_on:
-            import time
-
-            self._run_id = int(time.time())
 
         self.frames = []  # List to store frames for video generation
 
@@ -596,7 +587,7 @@ class GraphicalRenderer(Renderer):
             # Define video properties based on the first frame
             height, width, _ = self.frames[0].shape
             output_path = os.path.join(self.out_dir_path,
-                                       f'simulation_video_{self._run_id}.mp4')
+                                       'simulation_video.mp4')
 
             # Create video writer
             fourcc = cv2.VideoWriter_fourcc(*'mp4v')

--- a/tests/test_actionhandler.py
+++ b/tests/test_actionhandler.py
@@ -80,7 +80,8 @@ class TestActionHandler(unittest.TestCase):
 
         # Verify the flower was placed on the grid
         self.grid_world.place_flower.assert_called_with(self.agent.position,
-                                                        flower_type)
+                                                        flower_type,
+                                                        self.agent)
 
         # Verify the flowers planted by the agent are incremented
         self.assertEqual(self.agent.flowers_planted[0], 1)
@@ -116,6 +117,7 @@ class TestActionHandler(unittest.TestCase):
         mock_cell.flower = mock_flower
         mock_flower.is_grown.return_value = True
         mock_flower.flower_type = 0
+        mock_flower.planted_by = self.agent
 
         self.grid_world.get_cell.return_value = mock_cell
         self.grid_world.flowers_data = {0: {'price': 10.0}}

--- a/tests/test_flower.py
+++ b/tests/test_flower.py
@@ -1,4 +1,7 @@
 import unittest
+from unittest.mock import Mock
+
+from ethicalgardeners.agent import Agent
 from ethicalgardeners.gridworld import Flower
 
 
@@ -18,8 +21,9 @@ class TestFlower(unittest.TestCase):
             1: {"price": 5, "pollution_reduction": [0, 0, 1, 3]},
             2: {"price": 2, "pollution_reduction": [1]}
         }
+        self.agent = Mock(spec=Agent)
         self.flower = Flower(self.position, self.flower_type,
-                             self.flowers_data)
+                             self.flowers_data, self.agent)
 
     def test_grow_from_initial_stage(self):
         """Test flower growth from its initial stage.

--- a/tests/test_gridworld.py
+++ b/tests/test_gridworld.py
@@ -17,7 +17,7 @@ class TestWorldGrid(unittest.TestCase):
         self.temp_file_path = self.temp_file.name
         self.temp_file.write(b"5 5\n")
         self.temp_file.write(b"G G G O O\n")
-        self.temp_file.write(b"G F0_0_2 G G O\n")
+        self.temp_file.write(b"G F0_2 G G O\n")
         self.temp_file.write(b"G O G A0 O\n")
         self.temp_file.write(b"G G G G O\n")
         self.temp_file.write(b"O O O O O\n")
@@ -85,7 +85,6 @@ class TestWorldGrid(unittest.TestCase):
         self.assertTrue(self.test_grid.grid[1][1].has_flower())
         flower = self.test_grid.grid[1][1].flower
         self.assertEqual(flower.flower_type, 0)
-        self.assertEqual(flower.planted_by, self.test_grid.agents[0])
         self.assertEqual(flower.current_growth_stage, 2)
 
         # Check agent placement

--- a/tests/test_gridworld.py
+++ b/tests/test_gridworld.py
@@ -17,7 +17,7 @@ class TestWorldGrid(unittest.TestCase):
         self.temp_file_path = self.temp_file.name
         self.temp_file.write(b"5 5\n")
         self.temp_file.write(b"G G G O O\n")
-        self.temp_file.write(b"G F0_2 G G O\n")
+        self.temp_file.write(b"G F0_0_2 G G O\n")
         self.temp_file.write(b"G O G A0 O\n")
         self.temp_file.write(b"G G G G O\n")
         self.temp_file.write(b"O O O O O\n")
@@ -85,6 +85,7 @@ class TestWorldGrid(unittest.TestCase):
         self.assertTrue(self.test_grid.grid[1][1].has_flower())
         flower = self.test_grid.grid[1][1].flower
         self.assertEqual(flower.flower_type, 0)
+        self.assertEqual(flower.planted_by, self.test_grid.agents[0])
         self.assertEqual(flower.current_growth_stage, 2)
 
         # Check agent placement

--- a/tests/test_metricscollector.py
+++ b/tests/test_metricscollector.py
@@ -88,7 +88,7 @@ class TestMetricsCollector(unittest.TestCase):
 
         # Check if the file was created
         expected_filename = (
-            os.path.join(self.temp_dir, "metrics_run.csv")
+            os.path.join(self.temp_dir, "simulation_metrics.csv")
         )
         self.assertTrue(os.path.exists(expected_filename))
 

--- a/tests/test_metricscollector.py
+++ b/tests/test_metricscollector.py
@@ -88,8 +88,7 @@ class TestMetricsCollector(unittest.TestCase):
 
         # Check if the file was created
         expected_filename = (
-            os.path.join(self.temp_dir,
-                         f"metrics_run_{self.collector._run_id}.csv")
+            os.path.join(self.temp_dir, "metrics_run.csv")
         )
         self.assertTrue(os.path.exists(expected_filename))
 


### PR DESCRIPTION
## Features
- Add hydra override in config.yaml to put the hydra logs in the same directory as the metrics
- Delete hydra configs logs if export_on is False (not main.log because when the program is running, main.log is being used to write into)
- Change metrics output directory using timestamps for easier reading
- Fix informations in tutorials
- Fix flower harvesting by adding the ‘planted_by’ attribute to keep track of which agent planted the flower to remove it from its flowers_planted dictionary instead of removing it from the agent that harvested the flower